### PR TITLE
fix: no longer blockify blank pages

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -62,7 +62,7 @@ class PdfBlockifier(Blockifier):
             text = page.extract_text()
 
             # Blank pages cause empty blocks, which cause problems for embedders.
-            if text = "": 
+            if text == "": 
                 continue
                 
             # Fix an encoding bug that sometimes arises.

--- a/src/api.py
+++ b/src/api.py
@@ -61,6 +61,10 @@ class PdfBlockifier(Blockifier):
         for i, page in enumerate(pdf_reader.pages):
             text = page.extract_text()
 
+            # Blank pages cause empty blocks, which cause problems for embedders.
+            if text = "": 
+                continue
+                
             # Fix an encoding bug that sometimes arises.
             text = re.sub("\u0000", "", text)
                    


### PR DESCRIPTION
Blank blocks cause the embedding pipelines to throw an error.